### PR TITLE
Update for dbt 0.17

### DIFF
--- a/dbt/adapters/azuredw/impl.py
+++ b/dbt/adapters/azuredw/impl.py
@@ -6,9 +6,13 @@ class AzureDWAdapter(SQLAdapter):
     ConnectionManager = AzureDWConnectionManager
 
     @classmethod
-    def date_function(cls):
+    def date_function(cls) -> str:
         return 'get_date()'
 
     @classmethod
-    def convert_text_type(cls, agate_table, col_idx):
+    def convert_text_type(cls, agate_table, col_idx) -> str:
         return 'varchar(8000)'
+
+    @classmethod
+    def is_cancelable(cls) -> bool:
+        return False

--- a/dbt/include/azuredw/dbt_project.yml
+++ b/dbt/include/azuredw/dbt_project.yml
@@ -2,4 +2,6 @@
 name: dbt_azuredw
 version: 0.0.1
 
+config-version: 2
+
 macro-paths: ["macros"]

--- a/dbt/include/azuredw/dbt_project.yml
+++ b/dbt/include/azuredw/dbt_project.yml
@@ -1,7 +1,5 @@
-
 name: dbt_azuredw
-version: 0.0.1
-
+version: 0.0.2
 config-version: 2
 
 macro-paths: ["macros"]

--- a/dbt/include/azuredw/macros/adapters.sql
+++ b/dbt/include/azuredw/macros/adapters.sql
@@ -35,7 +35,7 @@
   {{ return(load_result('check_schema_exists').table) }}
 {% endmacro %}
 
-{% macro azuredw__list_relations_without_caching(information_schema, schema) %}
+{% macro azuredw__list_relations_without_caching(schema_relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     select
       table_catalog as [database],
@@ -45,9 +45,9 @@
            when table_type = 'VIEW' then 'view'
            else table_type
       end as table_type
-    from {{ information_schema }}.tables
-    where table_schema = '{{ schema }}'
-      and table_catalog = '{{ information_schema.database.lower() }}'
+    from {{ schema_relation.database }}.information_schema.tables
+    where table_schema = '{{ schema_relation.schema }}'
+      and table_catalog = '{{ schema_relation.database }}'
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}

--- a/dbt/include/azuredw/macros/catalog.sql
+++ b/dbt/include/azuredw/macros/catalog.sql
@@ -1,38 +1,36 @@
 
-{% macro azuredw__get_catalog(information_schemas) -%}
+{% macro azuredw__get_catalog(information_schema, schemas) -%}
     {%- call statement('catalog', fetch_result=True) -%}
-      {% if (information_schemas | length) != 1 %}
-        {{ exceptions.raise_compiler_error('redshift get_catalog requires exactly one database') }}
-      {% endif %}
-        {% set database = information_schemas[0].database %}
-        {% set schema = information_schemas[0].schema %}
-            with tables as (
-                select
-                    table_catalog as "table_database",
-                    table_schema as "table_schema",
-                    table_name as "table_name",
-                    case when table_type = 'BASE TABLE' then 'table'
-                        when table_type = 'VIEW' then 'view'
-                        else table_type
-                    end as table_type
-                from {{database}}.{{schema}}.tables
-            ),
-            columns as (
-                select
-                    table_catalog as "table_database",
-                    table_schema as "table_schema",
-                    table_name as "table_name",
-                    null as "table_comment",
-                    column_name as "column_name",
-                    ordinal_position as "column_index",
-                    data_type as "column_type",
-                    null as "column_comment"
-                from {{database}}.{{schema}}.columns
-            )
-            select *
-            from tables
-            join columns on tables.table_database = columns.table_database and tables.table_schema = columns.table_schema and tables.table_name = columns.table_name
-            order by "column_index"
-  {%- endcall -%}
-  {{ return(load_result('catalog').table) }}
+        {% set database = information_schema.database %}
+        {% set schema = schemas[0] %}
+        with tables as (
+            select
+                table_catalog as "table_database",
+                table_schema as "table_schema",
+                table_name as "table_name",
+                case when table_type = 'BASE TABLE' then 'table'
+                    when table_type = 'VIEW' then 'view'
+                    else table_type
+                end as table_type
+            from {{ information_schema }}.tables
+        ), columns as (
+            select
+                table_catalog as "table_database",
+                table_schema as "table_schema",
+                table_name as "table_name",
+                null as "table_comment",
+                column_name as "column_name",
+                ordinal_position as "column_index",
+                data_type as "column_type",
+                null as "column_comment"
+            from {{ information_schema }}.columns
+        )
+        select *
+        from tables
+        join columns on tables.table_database = columns.table_database
+            and tables.table_schema = columns.table_schema
+            and tables.table_name = columns.table_name
+        order by "column_index"
+    {%- endcall -%}
+    {{ return(load_result('catalog').table) }}
 {%- endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         ]
     },
     install_requires=[
-        'dbt-core>=0.14.0',
+        'dbt-core>=0.15.0',
         'pyodbc'
     ]
 )


### PR DESCRIPTION
Updating the azuredw adaptor to work with dbt >= 0.16.0

The included changes have been tested in my environment manually, but an automated test suite has not been applied.

A number of changes have been introduced from dbt 0.15.0, including:
* dropping support for Python2.7 (dbt.compat calls)
* changes to some jinja macro arguments
* changes to the Credentials class API and attribute structure
* added `is_cancelable()` function to go with `cancel` adaptor function

Other changes:
* using f-strings given python 3.x dependency

Some of the changes possibly should be applied to the upstream https://github.com/jacobm001/dbt-mssql adaptor project, however, I only use dbt with Azure Synapse (SQL DW).

Happy to split up the PR, if that is the preferred approach.